### PR TITLE
Make curl removal idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,8 @@
   become: yes
   become_user: root
   command: /opt/anaconda/bin/conda remove -y curl
+  args:
+    removes: /opt/anaconda/lib/libcurl.a
   
 - name: make system default python etc...
   become: yes


### PR DESCRIPTION
Added a removes check for the python library to avoid failing when re-running, as conda curl has already been removed.
