### PR TITLE
deprecation warning when running the ansible command

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,7 +25,9 @@ galaxy_info:
     - python
 
 dependencies:
-  - role: andrewrothstein.bash
+  - src: andrewrothstein.bash
     version: v1.0.1
-  - role: andrewrothstein.unarchive-deps
+    name: andrewrothstein.bash
+  - src: andrewrothstein.unarchive-deps
     version: v1.0.8
+    name: andrewrothstein.unarchive-deps


### PR DESCRIPTION
when running ansible, we get

- andrewrothstein.anaconda was installed successfully
[DEPRECATION WARNING]: The comma separated role spec format, use the
yaml/explicit format instead..
This feature will be removed in a future
release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

This is discussed https://github.com/ansible/ansible/pull/14612 and with the change the warning goes away