### PR TITLE
Do not report update task as changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
   become_user: root
   when: anaconda_pkg_update
   command: '{{anaconda_link_dir}}/bin/conda update -y --all'
+  changed_when: not anaconda_pkg_update
 
 - name: remove conda-curl since it conflicts with the system curl
   become: yes


### PR DESCRIPTION
Current behavior fails idempotency check.
At the same time I'd like to be able to update packages with the role for I use it in packer.
Please consider adding this. 