### PR TITLE
Removes unnecessary dependencies on other Ansible roles

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,4 @@ anaconda_parent_dir: /usr/local
 anaconda_link_subdir: anaconda
 
 anaconda_pkg_update: True
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,8 +25,3 @@ galaxy_info:
     - conda
     - anaconda
 
-dependencies:
-  - src: andrewrothstein.bash
-    version: v1.0.4
-  - src: andrewrothstein.unarchive-deps
-    version: v1.0.9

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+
+- name: install prerequisite packages
+  become: yes
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - bzip2
+    - tar
+
 - name: download installer...
   become: yes
   become_user: root


### PR DESCRIPTION
Although I agree that it's always good to be DRY, the dependency on other Ansible roles is just too much in this case.

`andrewrothstein.unarchive-deps` installs more packages than are minimally required: only `bzip2` and `tar` are actually needed. And, as far as I can tell, `andrewrothstein.bash` is not required at all.