### PR TITLE
Fix role relative variable resolution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,11 @@
 - name: resolve platform specific vars
   include_vars: "{{ item }}"
   with_first_found:
-    - '{{ ansible_os_family }}.yml'
-    - 'default.yml'
+    - files:
+        - '{{ ansible_os_family }}.yml'
+        - 'default.yml'
+      paths:
+        - '{{ role_path }}/vars'
 
 - name: check for installation of Anaconda
   become: yes


### PR DESCRIPTION
- According to Ansible issue #18417
  (https://github.com/ansible/ansible/issues/18417)
  the variable resolution by a combination of "include_vars"
  and "with_first_found" resolves the file in the parent role
  first, which will likely lead to unexepected behaviour, if
  this role is included as a dependency and the parent role
  includes variable files with matching names.