### PR TITLE
Check installation in the anaconda_install_dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: check for installation of Anaconda
   become: yes
   stat:
-    path: '{{ anaconda_conda_bin }}'
+    path: '{{ anaconda_install_dir }}/bin/conda'
   changed_when: false
   register: anaconda_conda_binary
 


### PR DESCRIPTION
- Check installation of Anaconda in the {{ anaconda_install_dir }}
- NOT in `/usr/local/anaconda` directory, as it is a symlink pointing to install dir
- Otherwise we won't be able to install a different version