### PR TITLE
Support Anaconda channels for packages installation and fix conditional check error

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,8 @@ anaconda_link_subdir: anaconda
 
 anaconda_pkg_update: True
 anaconda_install_packages: []
+anaconda_install_channels: ""
+# e.g.: anaconda_install_channels: "defaults conda-forge bioconda"
 
 # additional control over windows-installer specific options
 win_anaconda_installation_type: JustMe

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -76,6 +76,4 @@
     state: present
     executable: "{{ anaconda_conda_bin }}"
     channels: "{{ anaconda_install_channels }}"
-  register: conda_install_result
-  changed_when: not (conda_install_result.stdout | search('All requested packages already installed'))
   with_items: "{{anaconda_install_packages}}"

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -75,6 +75,7 @@
     name: "{{ item }}"
     state: present
     executable: "{{ anaconda_conda_bin }}"
+    channels: "{{ anaconda_install_channels }}"
   register: conda_install_result
   changed_when: not (conda_install_result.stdout | search('All requested packages already installed'))
   with_items: "{{anaconda_install_packages}}"


### PR DESCRIPTION
Just as the name suggests, support the channels for the conda command. 

Furthermore: on Ansible 2.5.5 on an Scientific Linux 7.5 system the following error occurs:

> FAILED! => {"msg": "The conditional check 'not (conda_install_result.stdout | search('All requested packages already installed'))' failed. The error was: Unexpected templating type error occurred on ({% if not (conda_install_result.stdout | search('All requested packages already installed')) %} True {% else %} False {% endif %}): expected string or buffer"}

Since the conda module itself handles the changed/unchanged declaration the check changed_when is obsolete altogether. Removing that check has an additional benefit since it removes the following warning:

> [DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|search` instead use `result is search`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.