### PR TITLE
Add `anaconda_tmp_dir` var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -154,3 +154,5 @@ anaconda_checksums:
   Anaconda3-2021.11-MacOSX-x86_64.sh: sha256:6a9217d1a08c599f860045d56ef64fc6c3e3112b55cc97f3d07c573d7bbcdb58
   # https://repo.anaconda.com/archive/Anaconda3-2021.11-Windows-x86_64.exe
   Anaconda3-2021.11-Windows-x86_64.exe: sha256:1b3d593d1deb22b835be5c68897075e0fc9dea240ab4191c55674aba259a78ff
+
+anaconda_tmp_dir: /tmp

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -15,6 +15,11 @@
 
 - when: not anaconda_conda_binary.stat.exists
   block:
+    - name: ensure that {{ anaconda_tmp_dir }} directory exists
+      file:
+        path: "{{ anaconda_tmp_dir }}"
+        state: directory
+
     - name: downloading {{ anaconda_installer_url }} to {{ anaconda_installer_tmp_sh }}
       become: true
       become_user: root
@@ -28,7 +33,7 @@
     - name: launching installer {{ anaconda_installer_tmp_sh }} with bash
       become: true
       become_user: root
-      command: bash {{ anaconda_installer_tmp_sh }} -b -p {{ anaconda_install_dir }}
+      shell: 'TMPDIR={{ anaconda_tmp_dir }} bash {{ anaconda_installer_tmp_sh }} -b -p {{ anaconda_install_dir }}'
       args:
         creates: '{{ anaconda_install_dir }}'
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 anaconda_platform: '{{ anaconda_os_installer_discriminator }}-{{ ansible_machine }}'
 anaconda_name: 'Anaconda{{ anaconda_python_ver }}-{{ anaconda_ver }}-{{ anaconda_platform }}'
 anaconda_installer_sh: '{{ anaconda_name }}.sh'
-anaconda_installer_tmp_sh: /tmp/{{ anaconda_installer_sh }}
+anaconda_installer_tmp_sh: '{{ anaconda_tmp_dir }}/{{ anaconda_installer_sh }}'
 anaconda_installer_url: '{{ anaconda_mirror }}/{{ anaconda_installer_sh }}'
 anaconda_checksum: '{{ anaconda_checksums[anaconda_installer_sh] }}'
 


### PR DESCRIPTION
This is very nice to have, because on some systems, `/tmp` is mounted
with `noexec` and running the anaconda installer from it errors out
with something like:

```
TASK [ansible-anaconda : launching installer /root/tmp/Anaconda3-2021.11-Linux-x86_64.sh with bash] *********************************************************************
fatal: [abramowi-ansible-test-6]: FAILED! => {"changed": true, "cmd": ["bash", "/root/tmp/Anaconda3-2021.11-Linux-x86_64.sh", "-b", "-p", "/usr/local/Anaconda3-2021.11-Linux-x86_64"], "delta": "0:00:18.802309", "end": "2022-04-22 02:58:46.371616", "msg": "non-zero return code", "rc": 1, "start": "2022-04-22 02:58:27.569307", "stderr": "/usr/local/Anaconda3-2021.11-Linux-x86_64/conda.exe: error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted\n/usr/local/Anaconda3-2021.11-Linux-x86_64/conda.exe: error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted", "stderr_lines": ["/usr/local/Anaconda3-2021.11-Linux-x86_64/conda.exe: error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted", "/usr/local/Anaconda3-2021.11-Linux-x86_64/conda.exe: error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted"], "stdout": "PREFIX=/usr/local/Anaconda3-2021.11-Linux-x86_64\nUnpacking payload ...", "stdout_lines": ["PREFIX=/usr/local/Anaconda3-2021.11-Linux-x86_64", "Unpacking payload ..."]}
```

The solution is to allow using a different `TMPDIR` as described at
https://stackoverflow.com/questions/60106630/conda-exe-error-while-loading-shared-libraries-libz-so-1

Without this, I get errors like the above while trying to provision an
Amazon Linux EC2 instance. With this, I can put this in my playbook:

```yaml
     - name: Include ansible-anaconda role
       include_role:
         name: ansible-anaconda
         apply:
           tags: anaconda
       vars:
         anaconda_make_sys_default: True
         anaconda_tmp_dir: "{{ ansible_env.HOME }}/tmp"
         anaconda_umask: '022'
       when: install_anaconda
       tags: anaconda
```

and it works.