### PR TITLE
Add `anaconda_umask`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -156,3 +156,9 @@ anaconda_checksums:
   Anaconda3-2021.11-Windows-x86_64.exe: sha256:1b3d593d1deb22b835be5c68897075e0fc9dea240ab4191c55674aba259a78ff
 
 anaconda_tmp_dir: /tmp
+
+# It might be necessary to change the umask on some systems, so that users
+# other than "root" can use anaconda.
+#
+# anaconda_umask: '022'
+anaconda_umask: ''

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -33,7 +33,11 @@
     - name: launching installer {{ anaconda_installer_tmp_sh }} with bash
       become: true
       become_user: root
-      shell: 'TMPDIR={{ anaconda_tmp_dir }} bash {{ anaconda_installer_tmp_sh }} -b -p {{ anaconda_install_dir }}'
+      shell: |
+        (
+          [ ! -z "{{ anaconda_umask }}" ] && umask {{ anaconda_umask }}
+          TMPDIR={{ anaconda_tmp_dir }} bash {{ anaconda_installer_tmp_sh }} -b -p {{ anaconda_install_dir }}
+        )
       args:
         creates: '{{ anaconda_install_dir }}'
 
@@ -57,7 +61,11 @@
   become: true
   become_user: root
   when: anaconda_pkg_update
-  command: '{{ anaconda_conda_bin }} update -y --all'
+  shell: |
+    (
+      [ ! -z "{{ anaconda_umask }}" ] && umask {{ anaconda_umask }}
+      {{ anaconda_conda_bin }} update -y --all
+    )
 
 - name: remove conda-curl since it conflicts with the system curl
   become: true


### PR DESCRIPTION
Allow setting a custom umask, because on some systems (e.g.: an Amazon
Linux EC2 instance I'm testing with, the umask is set by default in
`/etc/profile` to `027`. This causes anaconda to get installed with the
read and execute bits missing for world so normal users get errors when
they try to use anaconda tools.

With this, I can use:

```yaml
     - name: Include ansible-anaconda role
       include_role:
         name: ansible-anaconda
         apply:
           tags: anaconda
       vars:
         anaconda_make_sys_default: True
         anaconda_tmp_dir: "{{ ansible_env.HOME }}/tmp"
         anaconda_umask: '022'
       when: install_anaconda
       tags: anaconda
```

and anaconda gets installed so that it can be used by any user.

Note: This branch includes #38, because it touches the same lines and separating them would lead to merge conflicts. The "real" changes for this PR are in 781c8bc.